### PR TITLE
Add maintainers [skip ci]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,3 +44,6 @@ extra:
   recipe-maintainers:
     - kszucs
     - xzkostyan
+    - cpcloud
+    - xmnlab
+    - xhochy


### PR DESCRIPTION
@cpcloud @xmnlab it can help resolve dependency issues with ibis, are You OK with it?

@xhochy because You're already a maintainer of clickhouse-odbc feedstock.